### PR TITLE
fix clone url

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -25,7 +25,7 @@ Install prerequisites:
             $ sudo make install
 
 Set up the plotty directory:
-    $ git clone git@github.com/jamesbornholt/plotty
+    $ git clone git@github.com:jamesbornholt/plotty.git
     $ cd plotty
     $ mkdir cache
     $ mkdir cache/csv


### PR DESCRIPTION
at least for me the old url gives a fatal warning.
replaced it with the one github provides on the sidebar.
